### PR TITLE
1-1初級　画面遷移 修正

### DIFF
--- a/src/main/java/com/example/controller/AdministratorController.java
+++ b/src/main/java/com/example/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "administrator/login";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
管理者登録後、従業員一覧画面に飛んでしまうので、
ログイン画面に遷移するように修正しました。
ご確認宜しくお願い致します。